### PR TITLE
po: enable location in PO files

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,1 @@
-i18n.gettext('dynamic-wallpaper-editor', args: '--no-location', preset: 'glib')
+i18n.gettext('dynamic-wallpaper-editor', args: '--add-location=file', preset: 'glib')


### PR DESCRIPTION
The source file location has very useful information for the translator. It tells the translator which file and line the string comes from, and tells how many files use it. One can look at the source file location info extracted by Gettext and, e.g., assume whether the string is about keyboard shortcut or a AppStream description. So, please kindly accept this PR. Thanks in advance.