### PR TITLE
Implement plural-form strings

### DIFF
--- a/src/misc.py
+++ b/src/misc.py
@@ -62,7 +62,7 @@ def time_to_string(total_time):
 		message += str(ngettext("%s minute", "%s minutes", minutes) % minutes + ' ')
 	if seconds < 10:
 		seconds = '0' + str(seconds)
-	message += str(ngettext("%s second", "%s seconds", seconds) % seconds + ' ')
+	message += str(ngettext("%s second", "%s seconds", seconds) % seconds)
 	return message
 
 def get_hms(total_time):

--- a/src/misc.py
+++ b/src/misc.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gi, math
+from gettext import ngettext
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -54,14 +55,14 @@ def time_to_string(total_time):
 	message = ''
 	hours, minutes, seconds = get_hms(total_time)
 	if hours > 0:
-		message += str(_("%s hour(s)") % hours + ' ')
+		message += str(ngettext("%s hour", "%s hours", hours) % hours + ' ')
 	if minutes > 0:
 		if minutes < 10:
 			minutes = '0' + str(minutes)
-		message += str(_("%s minute(s)") % minutes + ' ')
+		message += str(ngettext("%s minute", "%s minutes", minutes) % minutes + ' ')
 	if seconds < 10:
 		seconds = '0' + str(seconds)
-	message += str(_("%s second(s)") % seconds)
+	message += str(ngettext("%s second", "%s seconds", seconds) % seconds + ' ')
 	return message
 
 def get_hms(total_time):

--- a/src/window.py
+++ b/src/window.py
@@ -335,11 +335,11 @@ class DWEWindow(Gtk.ApplicationWindow):
 		"""Update the total time in the statusbar."""
 		self.status_bar.pop(0)
 		total_time = self.get_total_time()
-		message = str(_("%s pictures") % self.view.length + ' - ')
+		message = str(ngettext("%s picture", "%s pictures",
+		                       self.view.length) % self.view.length + ' - ')
 		message += str(ngettext("Total time: %s second",
 		                        "Total time: %s seconds",
-		                        total_time)
-		                        % total_time + ' ')
+		                        total_time) % total_time)
 		if total_time >= 60:
 			message += ' = ' + time_to_string(total_time)
 		if self.check_24:

--- a/src/window.py
+++ b/src/window.py
@@ -17,6 +17,7 @@
 
 from gi.repository import Gtk, Gio, GdkPixbuf, GLib, Gdk
 import xml.etree.ElementTree as xml_parser
+from gettext import ngettext
 
 from .view import DWERowsView
 from .view import DWEThumbnailsView
@@ -335,7 +336,10 @@ class DWEWindow(Gtk.ApplicationWindow):
 		self.status_bar.pop(0)
 		total_time = self.get_total_time()
 		message = str(_("%s pictures") % self.view.length + ' - ')
-		message += str(_("Total time: %s second(s)") % total_time)
+		message += str(ngettext("Total time: %s second",
+		                        "Total time: %s seconds",
+		                        total_time)
+		                        % total_time + ' ')
 		if total_time >= 60:
 			message += ' = ' + time_to_string(total_time)
 		if self.check_24:


### PR DESCRIPTION
Uses [gettext.ngettext](https://docs.python.org/pt-br/3.8/library/gettext.html#gettext.NullTranslations.ngettext) to implement plural-form strings in "hour(s)", "minute(s)", etc.

Solves #39