### PR TITLE
update-translations: fix POT generation

### DIFF
--- a/update-translations.sh
+++ b/update-translations.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+echo "Configuring build directory \"_build\"..."
+[ -d _build ] && rm -rf _build
+meson . _build > /dev/null
+
 echo "Generating .pot file..."
-xgettext --from-code=UTF-8 --files-from=po/POTFILES --output=po/dynamic-wallpaper-editor.pot
+ninja -C _build dynamic-wallpaper-editor-pot
 
 if [ $# = 0 ]; then
 	echo "No parameter, exiting now."


### PR DESCRIPTION
Using `xgettext` directly will ignore any parameters set in `po/meson.build` — therefore ignoring `--add-location=file` and including file and line to the POT file.  By running meson and then `ninja <project>-pot`, `po/meson.build`parameters are honored.

Alternatively, instead of removing `_build` dir, `meson --reconfigure` to make sure the build directory gets updated using:
```
[ -d _build ] && opts='--reconfigure'
meson $opts . _build > /dev/null
```
Just let me know what you prefer.