### PR TITLE
Prepare for help files translation (issue #48)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,9 @@ me about it.
 	- application-wide actions, such as the about dialog or the help
 	- changing user's settings depending on their desktop environment
 		- wallpaper URI
-		- wallpaper adjustement
+		- wallpaper adjustment
 		- lockscreen URI
-		- lockscreen adjustement
+		- lockscreen adjustment
 	- writing files to `~/.var/app/com.github.maoschanz.DynamicWallpaperEditor/config/*.xml`
 
 >The point of writing files to this directory are:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ UI and help files translation:
    to translate the strings of this `.po` file. The string `translator-credits`
    should be translated by your name(s), it will be displayed in the "About"
    dialog.
-4. Please test your translation by placing your `.po` file in the proper place,
+4. You can test your translation by placing your `.po` file in the proper place,
    building and installing the application.
 5. Once your translation is ready to be submitted, run
 ```
@@ -40,7 +40,7 @@ git push
 ```
 6. And submit a "pull request"/"merge request".
 
-NOTE: In the sessions below: `LANG` is your language code typically represented
+NOTE: In the sections below: `LANG` is your language code typically represented
 by a language specification of the form ll or a combined language and country
 specification of the form ll_CC
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,26 +19,69 @@ using GNOME Builder.
 
 ## If you want to translate the app
 
-1. Fork the repo and clone it on your disk.
-2. Add your language to `po/LINGUAS`.
-3. Build the app once, and then run `ninja -C _build dynamic-wallpaper-editor-update-po`
-at the root of the project. It should produce a `.po` file for your language.
-It's also possible to run `./update-translations.sh xx`, where `xx` is the code
-for your language.
-4. Use a text editor or [an adequate app](https://flathub.org/apps/details/org.gnome.Gtranslator)
-to translate the strings of this `.po` file. The string `translator-credits`
-should be translated by your name(s), it will be displayed in the "About" dialog.
-5. If you want to test your translation: GNOME Builder isn't able to run a
-translated version of the app so export it as a `.flatpak` file and install it.
-6. Run
+For translating UI or help files, these introductory instructions apply to both
+UI and help files translation:
+
+1. Before starting the translation, fork the repo and clone it on your disk.
+   If already have it forked/cloned, make sure to rebase your fork first.
+2. Enable the language and generate the translation file as detailed in next
+   sections
+3. Translate using a text editor or [an adequate app](https://flathub.org/apps/details/org.gnome.Gtranslator)
+   to translate the strings of this `.po` file. The string `translator-credits`
+   should be translated by your name(s), it will be displayed in the "About"
+   dialog.
+4. Please test your translation by placing your `.po` file in the proper place,
+   building and installing the application.
+5. Once your translation is ready to be submitted, run
 ```
-git add po
+git add path/to/your/file.po
 git commit
 git push
 ```
-7. And submit a "pull request"/"merge request".
+6. And submit a "pull request"/"merge request".
 
-If you're just updating an existing translation, skip steps 2 and 3.
+NOTE: In the sessions below: `LANG` is your language code typically represented
+by a language specification of the form ll or a combined language and country
+specification of the form ll_CC
+
+### Translating UI
+
+*Make sure to check more instructions regarding translation in above section*
+
+If adding translation, do the following at the project's root directory:
+
+1. Include your language code LANG in `po/LINGUAS`.
+2. Run `meson _build` (add `--reconfigure` if `_build` dir exists)
+3. Run `ninja -C _build dynamic-wallpaper-editor-update-po`
+4. Your translation file should be in `po/LANG.po`
+
+If updating your translation, just run `./update-translations.sh src_lang LANG`
+and your `po/LANG.po` will be updated with latest strings for translation
+
+If you want to test your translation: GNOME Builder isn't able to run a
+translated version of the app so export it as a `.flatpak` file and install it.
+
+### Translation help files
+
+*Make sure to check more instructions regarding translation in above section*
+
+If adding translation, do the following at the project's root directory:
+
+1. Include your language code LANG in `help/LINGUAS`.
+2. Run `meson _build` (add `--reconfigure` if `_build` dir exists)
+3. Run `ninja -C _build help-dynamic-wallpaper-editor-pot`
+4. Create directory for your language running `mkdir help/LANG`
+5. Run `msginit -i help/dynamic-wallpaper-editor.pot -o help/LANG/LANG.po`
+6. Now your translation file `help/LANG/LANG.po` is ready for translation
+
+If updating your translation, just run `./update-translations.sh help_all`
+and your `po/LANG/LANG.po` will be updated with latest strings for translation
+
+If you want to test your translation:
+
+1. Run `DESTDIR="/tmp" ninja -C _build install`
+2. View it running `yelp /tmp/usr/local/share/help/LANG/index.page`
+3. Alternatively, build and install the app and press F1 key for help pages
 
 ----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,15 +74,26 @@ If adding translation, do the following at the project's root directory:
 5. Run `msginit -i help/dynamic-wallpaper-editor.pot -o help/LANG/LANG.po`
 6. Now your translation file `help/LANG/LANG.po` is ready for translation
 
-If updating your translation, just run `./update-translations.sh help_all`
+If updating your translation, just run `./update-translations.sh help_lang LANG`
 and your `po/LANG/LANG.po` will be updated with latest strings for translation
 
-If you want to test your translation:
+If you want to test your translation, do the following from the directory where
+your language is located in the source code repository (e.g. `help/fr/fr.po`)
 
-1. Run `DESTDIR="/tmp" ninja -C _build install`
-2. View it running `yelp /tmp/usr/local/share/help/LANG/index.page`
-3. Alternatively, build and install the app and press F1 key for help pages
-
+1. Replacing `LANG` with your language code, run the command below:
+```
+lang=LANG
+msgfmt -co "$lang.mo" "$lang.po"
+for page in ../C/*.page; do  itstool -m "$lang.mo" -o . "$page"; done
+ln -s ../C/legal.xml .
+ln -s ../C/figures figures
+```
+2. See the documentation running:
+```
+yelp index.page
+```
+3. If satisfied with the translation, submit your `help/LANG/LANG.po`
+   (ignoring .page files and legal.xml and figures symlinks)
 ----
 
 ## If you want to fix a bug or to add a new feature

--- a/help/LINGUAS
+++ b/help/LINGUAS
@@ -1,0 +1,1 @@
+# please keep this list sorted alphabetically

--- a/help/meson.build
+++ b/help/meson.build
@@ -1,3 +1,6 @@
+# Tool required for dealing with translated help files
+itstool = find_program('itstool')
+
 gnome = import('gnome')
 gnome.yelp(meson.project_name(),
 	sources: [

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ project(
 
 i18n = import('i18n')
 
+itstool = find_program('itstool')
+
 subdir('data')
 subdir('help')
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -6,8 +6,6 @@ project(
 
 i18n = import('i18n')
 
-itstool = find_program('itstool')
-
 subdir('data')
 subdir('help')
 subdir('src')

--- a/src/ui/menus.ui
+++ b/src/ui/menus.ui
@@ -228,8 +228,8 @@
         </item>
         <item>
           <attribute name="action">app.wp_options</attribute>
-          <attribute name="label" translatable="yes">Streched</attribute>
-          <attribute name="target">streched</attribute>
+          <attribute name="label" translatable="yes">Stretched</attribute>
+          <attribute name="target">stretched</attribute>
         </item>
         <item>
           <attribute name="action">app.wp_options</attribute>

--- a/src/window.py
+++ b/src/window.py
@@ -284,7 +284,7 @@ class DWEWindow(Gtk.ApplicationWindow):
 			use_folder.set_boolean('slideshow-enabled', False)
 
 	def unsupported_desktop(self):
-		self.show_notification(_("This desktop environnement isn't supported."))
+		self.show_notification(_("This desktop environment isn't supported."))
 		self.app.lookup_action('wp_options').set_enabled(False)
 		self.lookup_action('set_wp').set_enabled(False)
 		return ''

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -15,6 +15,13 @@ function src_pot () {
 	ninja -C _build dynamic-wallpaper-editor-pot
 }
 
+function help_lang () {
+	echo "Updating .pot file"
+	help_pot
+	echo "Updating translation for: $1"
+	msgmerge --update --previous ./help/$1/$1.po ./help/dynamic-wallpaper-editor.pot
+}
+
 function help_all () {
 	ninja -C _build help-dynamic-wallpaper-editor-update-po
 }


### PR DESCRIPTION
This:
- Create `help/LINGUAS` with no languages, just a comment
- Add `itstool` to `meson.build`, otherwise `ninja -C _build help-dynamic-wallpaper-editor-pot` and `...-update-po`command would fail
- Edit `CONTRIBUTING.md` to include help files translations.

Regarding, `CONTRIBUTING.md`, I moved instructions the would apply to both UI and Help translations into a introductory section, then specific instructions to subsections. This of course resulting in rewriting part of the previously existent instructions.

Sadly, `ninja -C _build help-dynamic-wallpaper-editor-update-po` will fail if the translation file does not exist. I tried without the directory (`help/LANG`), then created that directory without `.po` file, and finally with the `.po` file. Only the last try worked. So, manual creation is required. Copying pot to po is an option, but would require too much manual edit of gettext fields. I opted to suggest using `msginit`

Fixes #48 