### PR TITLE
added some submenu to select time by hours, minutes, seconds

### DIFF
--- a/src/picture_widget.py
+++ b/src/picture_widget.py
@@ -66,16 +66,6 @@ class DWEPictureWidget(Gtk.Box):
 		self.static_time_btn.set_value(float(stt))
 		self.trans_time_btn.set_value(float(trt))
 
-		# Time spinn buttons
-		self.time_select_menu_btn = builder.get_object('time_select_menu_btn')
-		self.hour_sp = builder.get_object('hour_sp')
-		self.minute_sp = builder.get_object('minute_sp')
-		self.second_sp = builder.get_object('second_sp')
-		self.time_select_menu_btn.connect('toggled', self.on_time_select_menu_show)
-		self.hour_sp.connect('value-changed', self.on_hour_changed)
-		self.minute_sp.connect('value-changed', self.on_minute_changed)
-		self.second_sp.connect('value-changed', self.on_second_changed)
-
 		# Ability to be dragged
 		pic_box.drag_source_set(Gdk.ModifierType.BUTTON1_MASK, None, Gdk.DragAction.MOVE)
 		pic_box.connect('drag-data-get', self.on_drag_data_get)
@@ -136,30 +126,6 @@ class DWEPictureWidget(Gtk.Box):
 				self.image.set_from_icon_name('dialog-error-symbolic', Gtk.IconSize.DIALOG)
 				self.set_tooltip_text(_("This picture doesn't exist"))
 				self.time_box.set_sensitive(False)
-
-	############################################################################
-
-	def on_time_select_menu_show(self, *args):
-		value = self.static_time_btn.get_value()
-		seconds = value % 60
-		minutes = (value // 60) % 60
-		hours = ((value // 60) // 60) % 24
-		self.hour_sp.set_value(hours)
-		self.minute_sp.set_value(minutes)
-		self.second_sp.set_value(seconds)
-
-	def on_hour_changed(self, *args):
-		self.update_static()
-
-	def on_minute_changed(self, *args):
-		self.update_static()
-
-	def on_second_changed(self, *args):
-		self.update_static()
-
-	def update_static(self):
-		total = self.hour_sp.get_value() * 60 * 60 + self.minute_sp.get_value() * 60 + self.second_sp.get_value()
-		self.static_time_btn.set_value(total)
 
 	############################################################################
 

--- a/src/picture_widget.py
+++ b/src/picture_widget.py
@@ -66,6 +66,16 @@ class DWEPictureWidget(Gtk.Box):
 		self.static_time_btn.set_value(float(stt))
 		self.trans_time_btn.set_value(float(trt))
 
+		# Time spinn buttons
+		self.time_select_menu_btn = builder.get_object('time_select_menu_btn')
+		self.hour_sp = builder.get_object('hour_sp')
+		self.minute_sp = builder.get_object('minute_sp')
+		self.second_sp = builder.get_object('second_sp')
+		self.time_select_menu_btn.connect('toggled', self.on_time_select_menu_show)
+		self.hour_sp.connect('value-changed', self.on_hour_changed)
+		self.minute_sp.connect('value-changed', self.on_minute_changed)
+		self.second_sp.connect('value-changed', self.on_second_changed)
+
 		# Ability to be dragged
 		pic_box.drag_source_set(Gdk.ModifierType.BUTTON1_MASK, None, Gdk.DragAction.MOVE)
 		pic_box.connect('drag-data-get', self.on_drag_data_get)
@@ -126,6 +136,30 @@ class DWEPictureWidget(Gtk.Box):
 				self.image.set_from_icon_name('dialog-error-symbolic', Gtk.IconSize.DIALOG)
 				self.set_tooltip_text(_("This picture doesn't exist"))
 				self.time_box.set_sensitive(False)
+
+	############################################################################
+
+	def on_time_select_menu_show(self, *args):
+		value = self.static_time_btn.get_value()
+		seconds = value % 60
+		minutes = (value // 60) % 60
+		hours = ((value // 60) // 60) % 24
+		self.hour_sp.set_value(hours)
+		self.minute_sp.set_value(minutes)
+		self.second_sp.set_value(seconds)
+
+	def on_hour_changed(self, *args):
+		self.update_static()
+
+	def on_minute_changed(self, *args):
+		self.update_static()
+
+	def on_second_changed(self, *args):
+		self.update_static()
+
+	def update_static(self):
+		total = self.hour_sp.get_value() * 60 * 60 + self.minute_sp.get_value() * 60 + self.second_sp.get_value()
+		self.static_time_btn.set_value(total)
 
 	############################################################################
 

--- a/src/time_selector_popup.py
+++ b/src/time_selector_popup.py
@@ -1,0 +1,66 @@
+from gi.repository import Gtk
+import math
+
+UI_PATH = '/com/github/maoschanz/DynamicWallpaperEditor/ui/'
+
+class TimeSelectorPopup(Gtk.Popover):
+
+	def __init__(self, parent, start_hours, start_minutes, start_seconds, end_hours, end_minutes, end_seconds):
+		self.start_hours = start_hours
+		self.start_minutes = start_minutes
+		self.start_seconds = start_seconds
+
+		self.end_hours = end_hours
+		self.end_minutes = end_minutes
+		self.end_seconds = end_seconds
+
+		self.parent = parent #Widget that might be changed …
+
+		self.build_ui()
+
+	def build_ui(self):
+		builder = Gtk.Builder().new_from_resource(UI_PATH + "time_selector_popup.ui")
+		self.sp_start_hours = builder.get_object('sp_start_hours')
+		self.sp_start_minutes = builder.get_object('sp_start_minutes')
+		self.sp_start_seconds = builder.get_object('sp_start_seconds')
+
+		self.sp_end_hours = builder.get_object('sp_end_hours')
+		self.sp_end_minutes = builder.get_object('sp_end_minutes')
+		self.sp_end_seconds = builder.get_object('sp_end_seconds')
+
+		self.sp_start_hours.connect('value-changed', self.on_start_hours_changed)
+		self.sp_start_minutes.connect('value-changed', self.on_start_minutes_changed)
+		self.sp_start_seconds.connect('value-changed', self.on_start_seconds_changed)
+
+		self.sp_end_hours.connect('value-changed', self.on_end_hours_changed)
+		self.sp_end_minutes.connect('value-changed', self.on_end_minutes_changed)
+		self.sp_end_seconds.connect('value-changed', self.on_end_seconds_changed)
+
+		self.sp_start_hours.set_value(self.start_hours)
+		self.sp_start_minutes.set_value(self.start_minutes)
+		self.sp_start_seconds.set_value(self.start_seconds)
+
+		self.sp_end_hours.set_value(self.end_hours)
+		self.sp_end_minutes.set_value(self.end_minutes)
+		self.sp_end_seconds.set_value(self.end_seconds)
+
+	def on_start_hours_changed(self, *args):
+		self.update()
+
+	def on_start_minutes_changed(self, *args):
+		self.update()
+
+	def on_start_seconds_changed(self, *args):
+		self.update()
+
+	def on_end_hours_changed(self, *args):
+		self.update()
+
+	def on_end_minutes_changed(self, *args):
+		self.update()
+
+	def on_end_seconds_changed(self, *args):
+		self.update()
+
+	def update(self):
+		pass #Connect time update here …

--- a/src/ui/dynamic-wallpaper-editor.gresource.xml
+++ b/src/ui/dynamic-wallpaper-editor.gresource.xml
@@ -8,5 +8,6 @@
     <file>ui/start_time.ui</file>
     <file>ui/shortcuts.ui</file>
     <file>ui/window.ui</file>
+    <file>ui/time_selector_popup.ui</file>
   </gresource>
 </gresources>

--- a/src/ui/picture_thumbnail.ui
+++ b/src/ui/picture_thumbnail.ui
@@ -1,426 +1,220 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
 <interface domain="dynamic-wallpaper-editor">
-  <requires lib="gtk+" version="3.12"/>
-  <object class="GtkAdjustment" id="adjustment_hour">
-    <property name="upper">23</property>
+
+  <object class="GtkAdjustment" id="adjustment_st">
+    <property name="lower">1</property>
+    <property name="upper">86400</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+    <property name="value">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment_minutes">
-    <property name="upper">59</property>
+  <object class="GtkAdjustment" id="adjustment_tr">
+    <property name="lower">0</property>
+    <property name="upper">86400</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+    <property name="value">0</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment_seconds">
-    <property name="upper">59</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkPopover" id="clock_popover">
-    <property name="can_focus">False</property>
+
+  <object class="GtkEventBox" id="pic_box">
+    <property name="visible">True</property>
+    <property name="expand">True</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">5</property>
+        <property name="spacing">4</property>
+        <property name="margin">4</property>
+        <property name="orientation">vertical</property>
+
         <child>
-          <object class="GtkSpinButton" id="hour_sp">
+          <object class="GtkImage" id="pic_thumbnail">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="text" translatable="yes">11</property>
-            <property name="input_purpose">digits</property>
-            <property name="orientation">vertical</property>
-            <property name="adjustment">adjustment_hour</property>
-            <property name="numeric">True</property>
-            <property name="wrap">True</property>
+            <property name="expand">False</property>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="pack-type">start</property>
           </packing>
         </child>
+
         <child>
-          <object class="GtkLabel">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label" translatable="yes">:</property>
-            <attributes>
-              <attribute name="size" value="30720"/>
-            </attributes>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">2</property>
+
+            <child>
+              <object class="GtkMenuButton" id="time_btn">
+                <property name="visible">True</property>
+                <property name="relief">none</property>
+                <property name="valign">center</property>
+                <property name="popover">time_popover</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Duration</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon-name">pan-down-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="alt_label">
+                <property name="visible">True</property>
+                <property name="label">file name</property>
+              </object>
+            </child>
+
+            <child>
+              <object class="GtkButton" id="delete_btn">
+                <property name="visible">True</property>
+                <property name="relief">none</property>
+                <property name="valign">center</property>
+                <property name="tooltip_text" translatable="yes">Delete</property>
+                <style><class name="destructive-action"/></style>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="icon-name">edit-delete-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
+            </child>
+
+            <child>
+              <object class="GtkMenuButton" id="menu_btn">
+                <property name="visible">True</property>
+                <property name="relief">none</property>
+                <property name="valign">center</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="icon-name">view-more-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
+            </child>
+
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="minute_sp">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="text" translatable="yes">11</property>
-            <property name="input_purpose">digits</property>
-            <property name="orientation">vertical</property>
-            <property name="adjustment">adjustment_minutes</property>
-            <property name="numeric">True</property>
-            <property name="wrap">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label" translatable="yes">:</property>
-            <attributes>
-              <attribute name="size" value="30720"/>
-            </attributes>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="second_sp">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="text" translatable="yes">11</property>
-            <property name="input_purpose">digits</property>
-            <property name="orientation">vertical</property>
-            <property name="adjustment">adjustment_seconds</property>
-            <property name="numeric">True</property>
-            <property name="wrap">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="pack-type">end</property>
           </packing>
         </child>
       </object>
     </child>
   </object>
-  <object class="GtkAdjustment" id="adjustment_st">
-    <property name="lower">1</property>
-    <property name="upper">86400</property>
-    <property name="value">10</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment_tr">
-    <property name="upper">86400</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
+
+<!-- * -->
+
   <object class="GtkPopover" id="time_popover">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
+        <property name="margin">6</property>
         <property name="spacing">6</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="pic_label">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="label">picture name</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="static_label">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="label">static label</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
+            <style><class name="dim-label"/></style>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="transition_label">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="label">transition label</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
+            <style><class name="dim-label"/></style>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
+
         <child>
           <object class="GtkGrid" id="time_box">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="expand">False</property>
             <property name="halign">center</property>
-            <property name="row_spacing">5</property>
-            <property name="column_spacing">5</property>
+            <property name="row-spacing">5</property>
+            <property name="column-spacing">5</property>
+
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="expand">False</property>
                 <property name="label" translatable="yes">Time</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="static_btn">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="expand">False</property>
                 <property name="tooltip_text" translatable="yes">Time (in seconds) of this image. This doesn't include the time of the transition.</property>
                 <property name="adjustment">adjustment_st</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
+
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="expand">False</property>
                 <property name="label" translatable="yes">Transition</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="transition_btn">
+                <property name="expand">False</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Time (in seconds) of the transition between this image and the next one.</property>
                 <property name="adjustment">adjustment_tr</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkMenuButton" id="time_select_menu_btn">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="focus_on_click">False</property>
-                <property name="receives_default">True</property>
-                <property name="popover">clock_popover</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">10</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Select Time</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">pan-down-symbolic</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
+
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
         </child>
+
       </object>
     </child>
   </object>
-  <object class="GtkEventBox" id="pic_box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">4</property>
-        <child>
-          <object class="GtkImage" id="pic_thumbnail">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">2</property>
-            <child>
-              <object class="GtkMenuButton" id="time_btn">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="valign">center</property>
-                <property name="relief">none</property>
-                <property name="popover">time_popover</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">2</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Duration</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">pan-down-symbolic</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="alt_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">file name</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="delete_btn">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Delete</property>
-                <property name="valign">center</property>
-                <property name="relief">none</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">edit-delete-symbolic</property>
-                  </object>
-                </child>
-                <style>
-                  <class name="destructive-action"/>
-                </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkMenuButton" id="menu_btn">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">False</property>
-                <property name="valign">center</property>
-                <property name="relief">none</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">view-more-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
+
 </interface>
+
+

--- a/src/ui/picture_thumbnail.ui
+++ b/src/ui/picture_thumbnail.ui
@@ -1,219 +1,426 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.36.0 -->
 <interface domain="dynamic-wallpaper-editor">
-
-  <object class="GtkAdjustment" id="adjustment_st">
-    <property name="lower">1</property>
-    <property name="upper">86400</property>
+  <requires lib="gtk+" version="3.12"/>
+  <object class="GtkAdjustment" id="adjustment_hour">
+    <property name="upper">23</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
-    <property name="value">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment_tr">
-    <property name="lower">0</property>
-    <property name="upper">86400</property>
+  <object class="GtkAdjustment" id="adjustment_minutes">
+    <property name="upper">59</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
-    <property name="value">0</property>
   </object>
-
-  <object class="GtkEventBox" id="pic_box">
-    <property name="visible">True</property>
-    <property name="expand">True</property>
+  <object class="GtkAdjustment" id="adjustment_seconds">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkPopover" id="clock_popover">
+    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="spacing">4</property>
-        <property name="margin">4</property>
-        <property name="orientation">vertical</property>
-
+        <property name="can_focus">False</property>
+        <property name="spacing">5</property>
         <child>
-          <object class="GtkImage" id="pic_thumbnail">
+          <object class="GtkSpinButton" id="hour_sp">
             <property name="visible">True</property>
-            <property name="expand">False</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">11</property>
+            <property name="input_purpose">digits</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_hour</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
           </object>
           <packing>
-            <property name="pack-type">start</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
           </packing>
         </child>
-
         <child>
-          <object class="GtkBox">
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
-            <property name="spacing">2</property>
-
-            <child>
-              <object class="GtkMenuButton" id="time_btn">
-                <property name="visible">True</property>
-                <property name="relief">none</property>
-                <property name="valign">center</property>
-                <property name="popover">time_popover</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="spacing">2</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="label" translatable="yes">Duration</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="icon-name">pan-down-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkLabel" id="alt_label">
-                <property name="visible">True</property>
-                <property name="label">file name</property>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkButton" id="delete_btn">
-                <property name="visible">True</property>
-                <property name="relief">none</property>
-                <property name="valign">center</property>
-                <property name="tooltip_text" translatable="yes">Delete</property>
-                <style><class name="destructive-action"/></style>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="icon-name">edit-delete-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-
-            <child>
-              <object class="GtkMenuButton" id="menu_btn">
-                <property name="visible">True</property>
-                <property name="relief">none</property>
-                <property name="valign">center</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="icon-name">view-more-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">:</property>
+            <attributes>
+              <attribute name="size" value="30720"/>
+            </attributes>
           </object>
           <packing>
-            <property name="pack-type">end</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="minute_sp">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">11</property>
+            <property name="input_purpose">digits</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_minutes</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">:</property>
+            <attributes>
+              <attribute name="size" value="30720"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="second_sp">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">11</property>
+            <property name="input_purpose">digits</property>
+            <property name="orientation">vertical</property>
+            <property name="adjustment">adjustment_seconds</property>
+            <property name="numeric">True</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>
     </child>
   </object>
-
-<!-- * -->
-
+  <object class="GtkAdjustment" id="adjustment_st">
+    <property name="lower">1</property>
+    <property name="upper">86400</property>
+    <property name="value">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_tr">
+    <property name="upper">86400</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkPopover" id="time_popover">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="margin">6</property>
-        <property name="spacing">6</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
         <child>
           <object class="GtkLabel" id="pic_label">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="label">picture name</property>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="static_label">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="label">static label</property>
-            <style><class name="dim-label"/></style>
+            <style>
+              <class name="dim-label"/>
+            </style>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="transition_label">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="label">transition label</property>
-            <style><class name="dim-label"/></style>
+            <style>
+              <class name="dim-label"/>
+            </style>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
         </child>
-
         <child>
           <object class="GtkGrid" id="time_box">
             <property name="visible">True</property>
-            <property name="expand">False</property>
+            <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="row-spacing">5</property>
-            <property name="column-spacing">5</property>
-
+            <property name="row_spacing">5</property>
+            <property name="column_spacing">5</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="expand">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Time</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="static_btn">
                 <property name="visible">True</property>
-                <property name="expand">False</property>
+                <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Time (in seconds) of this image. This doesn't include the time of the transition.</property>
                 <property name="adjustment">adjustment_st</property>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">0</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
-
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="expand">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Transition</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="transition_btn">
-                <property name="expand">False</property>
                 <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <property name="tooltip_text" translatable="yes">Time (in seconds) of the transition between this image and the next one.</property>
                 <property name="adjustment">adjustment_tr</property>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
-
+            <child>
+              <object class="GtkMenuButton" id="time_select_menu_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="focus_on_click">False</property>
+                <property name="receives_default">True</property>
+                <property name="popover">clock_popover</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">10</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Select Time</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">pan-down-symbolic</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
         </child>
-
       </object>
     </child>
   </object>
-
+  <object class="GtkEventBox" id="pic_box">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">4</property>
+        <child>
+          <object class="GtkImage" id="pic_thumbnail">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">2</property>
+            <child>
+              <object class="GtkMenuButton" id="time_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="valign">center</property>
+                <property name="relief">none</property>
+                <property name="popover">time_popover</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Duration</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">pan-down-symbolic</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="alt_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">file name</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="delete_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Delete</property>
+                <property name="valign">center</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-delete-symbolic</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="destructive-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="menu_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="valign">center</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">view-more-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
 </interface>
-

--- a/src/ui/time_selector_popup.ui
+++ b/src/ui/time_selector_popup.ui
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.36.0 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkAdjustment" id="adjustment_end_hours">
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_end_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_end_seconds">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_start_hours">
+    <property name="upper">23</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_start_minutes">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_start_seconds">
+    <property name="upper">59</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkPopover" id="time_select_popup">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Start Time</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkSpinButton" id="sp_start_hours">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_start_hours</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="sp_start_minutes">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_start_minutes</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="sp_start_seconds">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_start_seconds</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">End time</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkSpinButton" id="sp_end_hours">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_end_hours</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="sp_end_minutes">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_end_minutes</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="sp_end_seconds">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="input_purpose">digits</property>
+                    <property name="orientation">vertical</property>
+                    <property name="adjustment">adjustment_end_seconds</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
Please notice that this will only allow to set the interval in hours, minutes and seconds; because using the spin button is painfully slow and ineffective. This might be changed in the future to control at which time of the day the image is going to be displayed …

However, in this current implementation it does only change the value of the current spin button and nothing more.
Controlling the start time would require to change the UI in the case that the fit day option is enabled - at least in my opinion.

_issue #55_