### PR TITLE
Fix save

### DIFF
--- a/src/data_model.py
+++ b/src/data_model.py
@@ -248,12 +248,12 @@ class DWEDataModel():
 			text += """
 	<static>
 		<file>""" + file_path + """</file>
-		<duration>""" + pic_structure['static'] + """</duration>
+		<duration>""" + str(pic_structure['static']) + """</duration>
 	</static>\n"""
 		next_file = self._get_next_path_from_index(pic_structure['index'])
 		if next_file is not None and pic_structure['transition'] > 0:
 			text += """	<transition type="overlay">
-		<duration>""" + pic_structure['transition'] + """</duration>
+		<duration>""" + str(pic_structure['transition']) + """</duration>
 		<from>""" + file_path + """</from>
 		<to>""" + next_file + """</to>
 	</transition>\n"""


### PR DESCRIPTION
i had an error while trying to save. this patch fixes it.

the error : 
```
Traceback (most recent call last):
  File "/usr/share/dynamic-wallpaper-editor/dynamic_wallpaper_editor/window.py", line 605, in action_save
    contents = self._data_model.export_to_xml().encode('utf-8')
  File "/usr/share/dynamic-wallpaper-editor/dynamic_wallpaper_editor/data_model.py", line 234, in export_to_xml
    raw_text += self._get_picture_xml(pic_structure)
  File "/usr/share/dynamic-wallpaper-editor/dynamic_wallpaper_editor/data_model.py", line 248, in _get_picture_xml
    text += """
TypeError: can only concatenate str (not "int") to str
```